### PR TITLE
Quick fix to kill lingering processes after exit

### DIFF
--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -129,8 +129,10 @@ Pcsx2App::Pcsx2App(void)
 
 Pcsx2App::~Pcsx2App(void)
 {
-	try {
-		vu1Thread.Cancel();
+	try
+	{
+		vu1Thread.Cancel(wxTimeSpan(0, 0, 5, 0));	// Quick fix to kill lingering processes that end up waiting here forever
+		//vu1Thread.Cancel();
 	}
 	DESTRUCTOR_CATCHALL
 }


### PR DESCRIPTION
Adds a 5 second timeout on an attempt to call **vu1Thread.Cancel()** inside pcsx2's destructor.

This should allow the lingering process to die after waiting 5 seconds for a mutex that will never unlock, but it does _**not**_ fix the actual problem of this scenario occurring.